### PR TITLE
Место расположения Скучного Места в виде GPX

### DIFF
--- a/boringplace.gpx
+++ b/boringplace.gpx
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx
+ version="1.0"
+ creator="OpenStreetMap.ru PersonalMap: http://openstreetmap.ru/?mapid=1319997191"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xmlns="http://www.topografix.com/GPX/1/0"
+ xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd"><metadata><name></name><desc></desc></metadata><wpt lat="51.530164093479" lon="46.050208210945"><name>Хаскспейс "Скучное Место"</name><cmt>Полуподвальное помещение под магазином "Музобоз".</cmt></wpt></gpx>

--- a/contacts.md
+++ b/contacts.md
@@ -19,6 +19,8 @@ permalink: /contacts/
   height="400px"
   src="http://openstreetmap.ru/frame.php?mapid=1319997191?noscreenshot=1">
 </iframe>
+Вы также можете скачать точку расположения в виде
+[GPX отметки](/boringplace.gpx).
 
 [назад](../index)
 

--- a/contacts.md
+++ b/contacts.md
@@ -19,6 +19,7 @@ permalink: /contacts/
   height="400px"
   src="http://openstreetmap.ru/frame.php?mapid=1319997191?noscreenshot=1">
 </iframe>
+Наш адрес: г. Саратов, Мичурина, д. 155 (угол Московская, д. 29)
 Вы также можете скачать точку расположения в виде
 [GPX отметки](/boringplace.gpx).
 

--- a/index.md
+++ b/index.md
@@ -18,6 +18,7 @@ layout: default
   height="400px"
   src="http://openstreetmap.ru/frame.php?mapid=1319997191&noscreenshot=1">
 </iframe>
+Наш адрес: г. Саратов, Мичурина, д. 155 (угол Московская, д. 29)
 Вы также можете скачать точку расположения в виде
 [GPX отметки](boringplace.gpx).
 

--- a/index.md
+++ b/index.md
@@ -18,6 +18,8 @@ layout: default
   height="400px"
   src="http://openstreetmap.ru/frame.php?mapid=1319997191&noscreenshot=1">
 </iframe>
+Вы также можете скачать точку расположения в виде
+[GPX отметки](boringplace.gpx).
 
 # [](#header-1)С чего мы начнём?
 


### PR DESCRIPTION
Добавлена ссылка на скачивание отметки расположения Скучного Места (и сама отметка) для картографического ПО. Теперь отметку можно скачать, залить в GIS-систему и нарисовать к ней маршрут. Полезно для тех, кто хочет доехать по навигатору или создателей карт.